### PR TITLE
fix: booting with usb wifi plugged in

### DIFF
--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -42,19 +42,18 @@ uci commit wireless
 # Configure secondary wifi-iface as the client to connect to the external Wifi AP
 # This is based on the assumption that the usb device will have longer range than the built in rpi
 if [ "$wifi_count" -gt 1 ]; then
-    uci set wireless.radio1.disabled='0'
+    uci set wireless.radio1.disabled='1'
     uci set wireless.radio1.channel='auto'
     # uci set wireless.radio1='wifi-device'
     # uci set wireless.radio1.channel='36'
     # uci set wireless.radio1.disabled='0'
 
-    uci set wireless.wifinet2='wifi-iface'
-    uci set wireless.wifinet2.disabled='1'
-    uci set wireless.wifinet2.device='radio1'
-    uci set wireless.wifinet2.mode="sta"
-    uci set wireless.wifinet2.network="wwan"
-    uci set wireless.wifinet2.encryption="$wlan_encryption"
-    uci set wireless.wifinet2.ssid="$wlan_name"
-    uci set wireless.wifinet2.key="$wlan_password"
+    uci set wireless.default_radio1.disabled='1'
+    uci set wireless.default_radio1.device='radio1'
+    uci set wireless.default_radio1.mode="sta"
+    uci set wireless.default_radio1.network="wwan"
+    uci set wireless.default_radio1.encryption="$wlan_encryption"
+    uci set wireless.default_radio1.ssid="$wlan_name"
+    uci set wireless.default_radio1.key="$wlan_password"
     uci commit wireless
 fi

--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -1,5 +1,6 @@
 wlan_name="OpenWRT"
 wlan_password="ChangeMe123456"
+wlan_encryption="psk2"
 
 lan_ip_address="192.168.1.1"
 
@@ -32,7 +33,7 @@ uci commit network
 uci set wireless.radio0.disabled='0'
 uci set wireless.default_radio0.disabled='0'
 uci set wireless.default_radio0.device="radio0"
-uci set wireless.default_radio0.encryption='psk2'
+uci set wireless.default_radio0.encryption='$wlan_encryption'
 uci set wireless.default_radio0.ssid="$wlan_name"
 uci set wireless.default_radio0.key="$wlan_password"
 uci set wireless.default_radio0.mode="ap"
@@ -48,9 +49,13 @@ if [ "$wifi_count" -gt 1 ]; then
     # uci set wireless.radio1.channel='36'
     # uci set wireless.radio1.disabled='0'
 
-    uci set wireless.default_radio1.disabled='0'
-    uci set wireless.default_radio1.device='radio1'
-    uci set wireless.default_radio1.mode="client"
-    uci set wireless.default_radio1.network="wwan"
+    uci set wireless.wifinet2='wifi-iface'
+    uci set wireless.wifinet2.disabled='0'
+    uci set wireless.wifinet2.device='radio1'
+    uci set wireless.wifinet2.mode="sta"
+    uci set wireless.wifinet2.network="wwan"
+    uci set wireless.wifinet2.encryption='$wlan_encryption'
+    uci set wireless.wifinet2.ssid='$wlan_name'
+    uci set wireless.wifinet2.key='$wlan_password'
     uci commit wireless
 fi

--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -49,7 +49,7 @@ if [ "$wifi_count" -gt 1 ]; then
     # uci set wireless.radio1.disabled='0'
 
     uci set wireless.wifinet2='wifi-iface'
-    uci set wireless.wifinet2.disabled='0'
+    uci set wireless.wifinet2.disabled='1'
     uci set wireless.wifinet2.device='radio1'
     uci set wireless.wifinet2.mode="sta"
     uci set wireless.wifinet2.network="wwan"

--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -4,9 +4,8 @@ wlan_encryption="psk2"
 
 lan_ip_address="192.168.1.1"
 
-# TODO: Find more reliable way to list wifi devices
-wifi_count=$(lsusb | wc -l)
-#eth_count=$(nmcli device | grep eth  | wc -l)
+# https://unix.stackexchange.com/a/552995
+wifi_count=$(ls /sys/class/ieee80211/*/device/net/* -d | wc -l)
 
 # log potential errors
 exec >/tmp/setup.log 2>&1

--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -49,7 +49,7 @@ uci commit wireless
 # Configure secondary wifi-iface as the client to connect to the external Wifi AP
 # This is based on the assumption that the usb device will have longer range than the built in rpi
 if [ "$wifi_count" -gt 1 ]; then
-    # Hardcode the built-in raspberry pi device to radio1
+    # Hardcode the usb device to radio1
     # https://forum.openwrt.org/t/list-option-paths-usb-radio-firstboot/96436
     usb_path=$(find /sys/devices/platform/soc/*usb*/ -name "net" | xargs dirname)
 

--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -27,9 +27,16 @@ uci set network.wwan.peerdns="0"
 uci set network.wwan.dns="9.9.9.9 1.1.1.1"
 uci commit network
 
-# Configure WLAN
+#### Configure WLAN ####
 # More options: https://openwrt.org/docs/guide-user/network/wifi/basic#wi-fi_interfaces
+####
+
+# Hardcode the built-in raspberry pi device to radio0
+# https://forum.openwrt.org/t/list-option-paths-usb-radio-firstboot/96436
+pi_path=$(find /sys/devices/platform/soc/*mmc*/ -name "net" | xargs dirname)
+
 uci set wireless.radio0.disabled='0'
+uci set wireless.radio0.path="${pi_path##/sys/devices/}"
 uci set wireless.default_radio0.disabled='0'
 uci set wireless.default_radio0.device="radio0"
 uci set wireless.default_radio0.encryption="$wlan_encryption"
@@ -42,8 +49,13 @@ uci commit wireless
 # Configure secondary wifi-iface as the client to connect to the external Wifi AP
 # This is based on the assumption that the usb device will have longer range than the built in rpi
 if [ "$wifi_count" -gt 1 ]; then
+    # Hardcode the built-in raspberry pi device to radio1
+    # https://forum.openwrt.org/t/list-option-paths-usb-radio-firstboot/96436
+    usb_path=$(find /sys/devices/platform/soc/*usb*/ -name "net" | xargs dirname)
+
     uci set wireless.radio1.disabled='1'
     uci set wireless.radio1.channel='auto'
+    uci set wireless.radio1.path="${usb_path##/sys/devices/}"
     # uci set wireless.radio1='wifi-device'
     # uci set wireless.radio1.channel='36'
     # uci set wireless.radio1.disabled='0'
@@ -56,4 +68,8 @@ if [ "$wifi_count" -gt 1 ]; then
     uci set wireless.default_radio1.ssid="$wlan_name"
     uci set wireless.default_radio1.key="$wlan_password"
     uci commit wireless
+
 fi
+
+# Restart wifi devices
+wifi

--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -32,7 +32,7 @@ uci commit network
 uci set wireless.radio0.disabled='0'
 uci set wireless.default_radio0.disabled='0'
 uci set wireless.default_radio0.device="radio0"
-uci set wireless.default_radio0.encryption='$wlan_encryption'
+uci set wireless.default_radio0.encryption="$wlan_encryption"
 uci set wireless.default_radio0.ssid="$wlan_name"
 uci set wireless.default_radio0.key="$wlan_password"
 uci set wireless.default_radio0.mode="ap"

--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -53,8 +53,8 @@ if [ "$wifi_count" -gt 1 ]; then
     uci set wireless.wifinet2.device='radio1'
     uci set wireless.wifinet2.mode="sta"
     uci set wireless.wifinet2.network="wwan"
-    uci set wireless.wifinet2.encryption='$wlan_encryption'
-    uci set wireless.wifinet2.ssid='$wlan_name'
-    uci set wireless.wifinet2.key='$wlan_password'
+    uci set wireless.wifinet2.encryption="$wlan_encryption"
+    uci set wireless.wifinet2.ssid="$wlan_name"
+    uci set wireless.wifinet2.key="$wlan_password"
     uci commit wireless
 fi


### PR DESCRIPTION
Ensure that radio0 is always the internal raspberry pi WiFi, and that radio1 is the external usb dongle. 