### PR TITLE
ci(fetch-openwrt-image): use image builder instead of firmware selector

### DIFF
--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -46,7 +46,7 @@ runs:
       shell: bash
       run: |
         cd ./build/openwrt && \
-        wget -r --no-parent -nd -A '*imagebuilder*' ${{ env.openwrt_targets }} && \
+        wget -r -q --no-parent -nd -A '*imagebuilder*' ${{ env.openwrt_targets }} && \
         tar -J -x -f openwrt-imagebuilder-*.tar.xz
 
     - name: Create uci-defaults

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -20,14 +20,10 @@ inputs:
     description: "Path to output the images into"
     required: false
     default: "./"
-  ofs_version:
-    description: "The OpenWRT Firmware Selector version"
-    required: false
-    default: "v4.0.3"
 outputs:
   image:
     description: "Path to the generated image file"
-    value: ${{ steps.download.outputs.image_name }}
+    value: ${{ steps.image.outputs.image_name }}
 
 runs:
   using: "composite"
@@ -38,60 +34,43 @@ runs:
     - name: setup
       shell: bash
       run: |
-        echo "openwrt_build_api=https://sysupgrade.openwrt.org/api/v1/build" >> $GITHUB_ENV
-        echo "openwrt_image_store=https://sysupgrade.openwrt.org/store" >> $GITHUB_ENV
+        echo "openwrt_targets=https://downloads.openwrt.org/snapshots/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
+        echo "openwrt_files=/build/openwrt/files" >> $GITHUB_ENV
 
-    - name: Read packages
-      uses: juliangruber/read-file-action@v1
+        mkdir -p ${{ env.openwrt_files }}
+
+        apt install build-essential libncurses-dev libncursesw-dev \
+        zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
+
+    - name: Download Image Builder
+      shell: bash
+      run: |
+        cd /build/openwrt && \
+        wget -r --no-parent -nd -A '*imagebuilder*' ${{ env.openwrt_targets }} && \
+        tar -J -x -f openwrt-imagebuilder-*.tar.xz
+
+    - name: Create uci-defaults
+      shell: bash
+      run: |
+        mkdir -p /build/openwrt/files/etc/uci-defaults
+        cp ${{ inputs.boot }} ${{env.openwrt_files}}/etc/uci-defaults/99-custom
+
+    - name: Create packages
+      shell: bash
       id: package
-      with:
-        path: ${{ inputs.packages }}
+      env:
+        package_file: ${{ inputs.packages }}
+      run: echo "packages=$(cat $package_file | jq -c -r 'join(" ")')" >> $GITHUB_OUTPUT
 
-    - name: Read defaults
-      uses: juliangruber/read-file-action@v1
-      id: defaults
-      with:
-        path: ${{ inputs.boot }}
-
-    - name: Request OpenWRT build
-      uses: fjogeleit/http-request-action@v1
-      id: request
-      with:
-        url: "${{ env.openwrt_build_api }}"
-        method: "POST"
-        customHeaders: '{"Content-Type": "application/json"}'
-        data: '{
-          "profile": "${{ inputs.firmware_id }}",
-          "target": "${{inputs.firmware_target }}",
-          "packages": ${{steps.package.outputs.content}},
-          "defaults": ${{ toJSON(steps.defaults.outputs.content) }},
-          "version": "${{ inputs.version }}",
-          "diff_packages": true,
-          "client": "ofs/${{ inputs.ofs_version }}"
-          }'
-
-    - name: Create build url
+    - name: Make image
       shell: bash
-      id: build_data
+      id: image
       run: |
-        echo "build_hash=${{ fromJson(steps.request.outputs.response).request_hash}}" >> $GITHUB_OUTPUT
-        echo "build_url=${{ env.openwrt_build_api}}/${{fromJson(steps.request.outputs.response).request_hash}}" >> $GITHUB_OUTPUT
+        cd /build/openwrt/openwrt-imagebuilder-*/ && \
+        make image \
+        PROFILE="${{inputs.firmware_id}}" \
+        PACKAGES="${{ steps.package.outputs.packages }}" \
+        FILES="${{env.openwrt_files}}" \
+        BIN_DIR="${{inputs.outdir}}"
 
-    - name: Wait for OpenWRT build
-      uses: mydea/action-wait-for-api@v1
-      with:
-        url: "${{ steps.build_data.outputs.build_url}}"
-        headers: '{"Content-Type": "application/json"}'
-        expected-status: "200"
-        timeout: "1800"
-
-    - name: Download factory image
-      shell: bash
-      id: download
-      run: |
-        image_name=$(curl -s -H 'Content-Type: application/json' '${{ steps.build_data.outputs.build_url }}' \
-          | jq -r '.images[] | select(.filesystem=="ext4" and .type=="factory" ) | .name');
-
-        wget -q -P ${{ inputs.outdir }} ${{env.openwrt_image_store}}/${{steps.build_data.outputs.build_hash}}/${image_name};
-
-        echo "image_name=${{ inputs.outdir }}/${image_name}" >> $GITHUB_OUTPUT
+        echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')"

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -47,7 +47,9 @@ runs:
         cd ~/build/openwrt && \
         wget -r -q --no-parent -nd -A '*imagebuilder*' ${{ env.openwrt_targets }} && \
         tar -J -x -f openwrt-imagebuilder-*.tar.xz && \
-        cd openwrt-imagebuilder-* && \
+        rm -rf openwrt-imagebuilder-*.tar.xz
+
+        cd ~/build/openwrt/openwrt-imagebuilder-*/ && \
         echo "openwrt_imagebuilder=$(pwd)" >> $GITHUB_ENV
 
     - name: Create uci-defaults

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: setup
       shell: bash
       run: |
-        echo "openwrt_targets=https://downloads.openwrt.org/snapshots/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
+        echo "openwrt_targets=https://downloads.openwrt.org/releases/${{ inputs.version }}/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
         echo "openwrt_files=~/build/openwrt/files" >> $GITHUB_ENV
 
         mkdir -p ~/build/openwrt/files

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -70,7 +70,8 @@ runs:
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \
-        FILES="${{env.openwrt_files}}" \
-        BIN_DIR="${{inputs.outdir}}"
+        FILES="${{env.openwrt_files}}"
+
+        cp $(find ./build/openwrt/. -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')"

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -39,7 +39,7 @@ runs:
 
         mkdir -p ./build/openwrt/files
 
-        sudo apt install build-essential libncurses-dev libncursesw-dev \
+        sudo apt update && sudo apt install build-essential libncurses-dev libncursesw-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
 
     - name: Download Image Builder

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -74,7 +74,7 @@ runs:
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \
-        FILES="files"
+        FILES="${{env.openwrt_files}}"
         BIN_DIR="${{ inputs.outdir }}"
 
     - name: Select output image

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -73,6 +73,6 @@ runs:
         PACKAGES="${{ steps.package.outputs.packages }}" \
         FILES="files"
 
-        cp $(find "${{env.openwrt_imagebuilder}}" -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
+        cp $(find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')" >> $GITHUB_OUTPUT

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -72,6 +72,6 @@ runs:
         PACKAGES="${{ steps.package.outputs.packages }}" \
         FILES="${{env.openwrt_files}}"
 
-        cp $(find ./build/openwrt/. -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
+        cp $(find ./build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')"

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -75,13 +75,10 @@ runs:
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \
         FILES="files"
-
-        find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz'
+        BIN_DIR="${{ inputs.outdir }}"
 
     - name: Select output image
       shell: bash
       id: image
       run: |
-        cp -f $(find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
-
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')" >> $GITHUB_OUTPUT

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         echo "openwrt_targets=https://downloads.openwrt.org/releases/${{ inputs.version }}/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
-        echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*/" >> $GITHUB_ENV
+        echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*" >> $GITHUB_ENV
 
         mkdir -p ~/build/openwrt
 
@@ -53,8 +53,9 @@ runs:
       shell: bash
       run: |
         cd ${{ env.openwrt_imagebuilder}} && \
-        mkdir -p files/etc/uci-defaults && \
-        cp ~/${{ inputs.boot }} files/etc/uci-defaults/99-custom
+        mkdir -p files/etc/uci-defaults
+
+        cp ${{ inputs.boot }} ${{ env.openwrt_imagebuilder}}/files/etc/uci-defaults/
 
     - name: Create packages
       shell: bash

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -35,7 +35,6 @@ runs:
       shell: bash
       run: |
         echo "openwrt_targets=https://downloads.openwrt.org/releases/${{ inputs.version }}/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
-        echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*" >> $GITHUB_ENV
 
         mkdir -p ~/build/openwrt
 
@@ -47,13 +46,15 @@ runs:
       run: |
         cd ~/build/openwrt && \
         wget -r -q --no-parent -nd -A '*imagebuilder*' ${{ env.openwrt_targets }} && \
-        tar -J -x -f openwrt-imagebuilder-*.tar.xz
+        tar -J -x -f openwrt-imagebuilder-*.tar.xz && \
+        cd openwrt-imagebuilder-* && \
+        echo "openwrt_imagebuilder=$(pwd)" >> $GITHUB_ENV
 
     - name: Create uci-defaults
       shell: bash
       run: |
-        cd ${{ env.openwrt_imagebuilder}} && \
-        mkdir -p files/etc/uci-defaults
+        mkdir -p ${{ env.openwrt_imagebuilder}}/files/etc/uci-defaults
+        echo "openwrt_files=${{ env.openwrt_imagebuilder}}/files" >> $GITHUB_ENV
 
         cp ${{ inputs.boot }} ${{ env.openwrt_imagebuilder}}/files/etc/uci-defaults/
 

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -73,6 +73,6 @@ runs:
         FILES="${{env.openwrt_files}}" \
         BIN_DIR="${{ inputs.outdir }}"
 
-        cp $(find ./build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
+        cp $(find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')"

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -65,7 +65,6 @@ runs:
 
     - name: Make image
       shell: bash
-      id: image
       run: |
         cd "${{env.openwrt_imagebuilder}}" && \
         make image \
@@ -73,6 +72,10 @@ runs:
         PACKAGES="${{ steps.package.outputs.packages }}" \
         FILES="files"
 
+    - name: Select output image
+      shell: bash
+      id: image
+      run: |
         cp $(find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')" >> $GITHUB_OUTPUT

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -39,7 +39,7 @@ runs:
 
         mkdir -p ./build/openwrt/files
 
-        sudo apt update && sudo apt install build-essential libncurses-dev libncursesw-dev \
+        sudo apt update && sudo apt install build-essential libncurses-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
 
     - name: Download Image Builder

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -37,7 +37,7 @@ runs:
         echo "openwrt_targets=https://downloads.openwrt.org/snapshots/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
         echo "openwrt_files=/build/openwrt/files" >> $GITHUB_ENV
 
-        mkdir -p ${{ env.openwrt_files }}
+        mkdir -p /build/openwrt/files
 
         apt install build-essential libncurses-dev libncursesw-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -35,9 +35,9 @@ runs:
       shell: bash
       run: |
         echo "openwrt_targets=https://downloads.openwrt.org/snapshots/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
-        echo "openwrt_files=./build/openwrt/files" >> $GITHUB_ENV
+        echo "openwrt_files=~/build/openwrt/files" >> $GITHUB_ENV
 
-        mkdir -p ./build/openwrt/files
+        mkdir -p ~/build/openwrt/files
 
         sudo apt update && sudo apt install build-essential libncurses-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
@@ -45,7 +45,7 @@ runs:
     - name: Download Image Builder
       shell: bash
       run: |
-        cd ./build/openwrt && \
+        cd ~/build/openwrt && \
         wget -r -q --no-parent -nd -A '*imagebuilder*' ${{ env.openwrt_targets }} && \
         tar -J -x -f openwrt-imagebuilder-*.tar.xz
 
@@ -66,7 +66,7 @@ runs:
       shell: bash
       id: image
       run: |
-        cd ./build/openwrt/openwrt-imagebuilder-*/ && \
+        cd ~/build/openwrt/openwrt-imagebuilder-*/ && \
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -39,7 +39,7 @@ runs:
 
         mkdir -p ./build/openwrt/files
 
-        apt install build-essential libncurses-dev libncursesw-dev \
+        sudo apt install build-essential libncurses-dev libncursesw-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
 
     - name: Download Image Builder

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -35,9 +35,8 @@ runs:
       shell: bash
       run: |
         echo "openwrt_targets=https://downloads.openwrt.org/releases/${{ inputs.version }}/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
-        echo "openwrt_files=~/build/openwrt/files" >> $GITHUB_ENV
-
-        mkdir -p ~/build/openwrt/files
+        echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*/" >> $GITHUB_ENV
+        echo "openwrt_files=~/build/openwrt/openwrt-imagebuilder-*/files/" >> $GITHUB_ENV
 
         sudo apt update && sudo apt install build-essential libncurses-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
@@ -66,13 +65,12 @@ runs:
       shell: bash
       id: image
       run: |
-        cd ~/build/openwrt/openwrt-imagebuilder-*/ && \
+        cd "${{env.openwrt_imagebuilder}}" && \
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \
-        FILES="${{env.openwrt_files}}" \
-        BIN_DIR="${{ inputs.outdir }}"
+        FILES="files" \
 
-        cp $(find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
+        cp $(find ${{env.openwrt_imagebuilder}} -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')" >> $GITHUB_OUTPUT

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -38,6 +38,8 @@ runs:
         echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*/" >> $GITHUB_ENV
         echo "openwrt_files=~/build/openwrt/openwrt-imagebuilder-*/files/" >> $GITHUB_ENV
 
+        mkdir -p ~/build/openwrt
+
         sudo apt update && sudo apt install build-essential libncurses-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
 

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -54,7 +54,7 @@ runs:
       run: |
         cd ${{ env.openwrt_imagebuilder}} && \
         mkdir -p files/etc/uci-defaults && \
-        cp ${{ inputs.boot }} files/etc/uci-defaults/99-custom
+        cp ~/${{ inputs.boot }} files/etc/uci-defaults/99-custom
 
     - name: Create packages
       shell: bash

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -70,7 +70,8 @@ runs:
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \
-        FILES="${{env.openwrt_files}}"
+        FILES="${{env.openwrt_files}}" \
+        BIN_DIR="${{ inputs.outdir }}"
 
         cp $(find ./build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -58,7 +58,7 @@ runs:
         mkdir -p ${{ env.openwrt_imagebuilder}}/files/etc/uci-defaults
         echo "openwrt_files=${{ env.openwrt_imagebuilder}}/files" >> $GITHUB_ENV
 
-        cp ${{ inputs.boot }} ${{ env.openwrt_imagebuilder}}/files/etc/uci-defaults/
+        cp ${{ inputs.boot }} ${{ env.openwrt_imagebuilder}}/files/etc/uci-defaults/99-custom
 
     - name: Create packages
       shell: bash

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -75,4 +75,4 @@ runs:
 
         cp $(find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
-        echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')"
+        echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')" >> $GITHUB_OUTPUT

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -35,8 +35,7 @@ runs:
       shell: bash
       run: |
         echo "openwrt_targets=https://downloads.openwrt.org/releases/${{ inputs.version }}/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
-        echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*" >> $GITHUB_ENV
-        echo "openwrt_files=~/build/openwrt/openwrt-imagebuilder-*/files" >> $GITHUB_ENV
+        echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*/" >> $GITHUB_ENV
 
         mkdir -p ~/build/openwrt
 
@@ -53,8 +52,9 @@ runs:
     - name: Create uci-defaults
       shell: bash
       run: |
-        mkdir -p ${{env.openwrt_files}}/etc/uci-defaults
-        cp ${{ inputs.boot }} ${{env.openwrt_files}}/etc/uci-defaults/99-custom
+        cd ${{ env.openwrt_imagebuilder}} && \
+        mkdir -p files/etc/uci-defaults && \
+        cp ${{ inputs.boot }} files/etc/uci-defaults/99-custom
 
     - name: Create packages
       shell: bash

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -76,6 +76,8 @@ runs:
         PACKAGES="${{ steps.package.outputs.packages }}" \
         FILES="files"
 
+        find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz'
+
     - name: Select output image
       shell: bash
       id: image

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -74,7 +74,7 @@ runs:
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \
-        FILES="${{env.openwrt_files}}"
+        FILES="${{env.openwrt_files}}/" \
         BIN_DIR="${{ inputs.outdir }}"
 
     - name: Select output image

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -35,9 +35,9 @@ runs:
       shell: bash
       run: |
         echo "openwrt_targets=https://downloads.openwrt.org/snapshots/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
-        echo "openwrt_files=/build-openwrt/files" >> $GITHUB_ENV
+        echo "openwrt_files=./build/openwrt/files" >> $GITHUB_ENV
 
-        mkdir -p /build-openwrt/files
+        mkdir -p ./build/openwrt/files
 
         apt install build-essential libncurses-dev libncursesw-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
@@ -45,7 +45,7 @@ runs:
     - name: Download Image Builder
       shell: bash
       run: |
-        cd /build-openwrt && \
+        cd ./build/openwrt && \
         wget -r --no-parent -nd -A '*imagebuilder*' ${{ env.openwrt_targets }} && \
         tar -J -x -f openwrt-imagebuilder-*.tar.xz
 
@@ -66,7 +66,7 @@ runs:
       shell: bash
       id: image
       run: |
-        cd /build-openwrt/openwrt-imagebuilder-*/ && \
+        cd ./build/openwrt/openwrt-imagebuilder-*/ && \
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -35,9 +35,9 @@ runs:
       shell: bash
       run: |
         echo "openwrt_targets=https://downloads.openwrt.org/snapshots/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
-        echo "openwrt_files=/build/openwrt/files" >> $GITHUB_ENV
+        echo "openwrt_files=/build-openwrt/files" >> $GITHUB_ENV
 
-        mkdir -p /build/openwrt/files
+        mkdir -p /build-openwrt/files
 
         apt install build-essential libncurses-dev libncursesw-dev \
         zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python3
@@ -45,14 +45,14 @@ runs:
     - name: Download Image Builder
       shell: bash
       run: |
-        cd /build/openwrt && \
+        cd /build-openwrt && \
         wget -r --no-parent -nd -A '*imagebuilder*' ${{ env.openwrt_targets }} && \
         tar -J -x -f openwrt-imagebuilder-*.tar.xz
 
     - name: Create uci-defaults
       shell: bash
       run: |
-        mkdir -p /build/openwrt/files/etc/uci-defaults
+        mkdir -p ${{env.openwrt_files}}/etc/uci-defaults
         cp ${{ inputs.boot }} ${{env.openwrt_files}}/etc/uci-defaults/99-custom
 
     - name: Create packages
@@ -66,7 +66,7 @@ runs:
       shell: bash
       id: image
       run: |
-        cd /build/openwrt/openwrt-imagebuilder-*/ && \
+        cd /build-openwrt/openwrt-imagebuilder-*/ && \
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -35,8 +35,8 @@ runs:
       shell: bash
       run: |
         echo "openwrt_targets=https://downloads.openwrt.org/releases/${{ inputs.version }}/targets/${{ inputs.firmware_target }}/" >> $GITHUB_ENV
-        echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*/" >> $GITHUB_ENV
-        echo "openwrt_files=~/build/openwrt/openwrt-imagebuilder-*/files/" >> $GITHUB_ENV
+        echo "openwrt_imagebuilder=~/build/openwrt/openwrt-imagebuilder-*" >> $GITHUB_ENV
+        echo "openwrt_files=~/build/openwrt/openwrt-imagebuilder-*/files" >> $GITHUB_ENV
 
         mkdir -p ~/build/openwrt
 
@@ -71,8 +71,8 @@ runs:
         make image \
         PROFILE="${{inputs.firmware_id}}" \
         PACKAGES="${{ steps.package.outputs.packages }}" \
-        FILES="files" \
+        FILES="files"
 
-        cp $(find ${{env.openwrt_imagebuilder}} -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
+        cp $(find "${{env.openwrt_imagebuilder}}" -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')" >> $GITHUB_OUTPUT

--- a/.github/actions/fetch-openwrt-image/action.yml
+++ b/.github/actions/fetch-openwrt-image/action.yml
@@ -80,6 +80,6 @@ runs:
       shell: bash
       id: image
       run: |
-        cp $(find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
+        cp -f $(find ~/build/openwrt/ -type f -name '*ext4*factory*.img.gz') ${{ inputs.outdir }}
 
         echo "image_name=$(find ${{ inputs.outdir }} -type f -name '*ext4*factory*.img.gz')" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/cache@v3
         id: openwrt-cache
         with:
-          path: "./openwrt-artifacts"
+          path: "~/openwrt-artifacts"
           key: ${{ matrix.version }}-${{ matrix.firmware.id }}-${{ hashFiles(format('{0}/*', matrix.image_dir) )}}
 
       - uses: ./.github/actions/fetch-openwrt-image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           firmware_target: ${{ matrix.firmware.target }}
           packages: ${{ matrix.image_dir }}/packages.json
           boot: ${{ matrix.image_dir }}/boot.sh
-          outdir: "./openwrt-artifacts"
+          outdir: "~/openwrt-artifacts"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/img/default/boot.sh
+++ b/img/default/boot.sh
@@ -36,6 +36,7 @@ uci set firewall.@zone[-1].network='lan'
 uci set firewall.@zone[-1].input='ACCEPT'
 uci set firewall.@zone[-1].output='ACCEPT'
 uci set firewall.@zone[-1].forward='ACCEPT'
+uci commit firewall
 
 # WAN
 uci add firewall zone
@@ -46,6 +47,7 @@ uci set firewall.@zone[-1].output='ACCEPT'
 uci set firewall.@zone[-1].forward='REJECT'
 uci set firewall.@zone[-1].masq='1'
 uci set firewall.@zone[-1].mtu_fix='1'
+uci commit firewall
 
 #### Configure Travelmate ####
 # More options: https://github.com/openwrt/packages/blob/master/net/travelmate/files/README.md
@@ -59,6 +61,7 @@ uci set travelmate.global.trm_netcheck="1"
 uci set travelmate.global.trm_proactive="1"
 uci set travelmate.global.trm_autoadd="1"
 uci set travelmate.global.trm_randomize="1"
+uci commit travelmate
 
 #### Configure WLAN ####
 # More options: https://openwrt.org/docs/guide-user/network/wifi/basic#wi-fi_interfaces


### PR DESCRIPTION
Firmware Selector has become increasingly unstable and creates a lot of false failures when it comes to building. By switching to the imagebuilder builds will become more stable by removing the dependency on the ever-changing api. 